### PR TITLE
Drawer over sitecontent

### DIFF
--- a/TheRestaurant/TheRestaurant.Presentation/Client/Shared/MainFooterComponent.razor
+++ b/TheRestaurant/TheRestaurant.Presentation/Client/Shared/MainFooterComponent.razor
@@ -1,6 +1,11 @@
-﻿
+﻿<style>
+    .footer-sticky {
+     position:sticky;
+     top: 0;
+    }
+</style>
 
-<MudPaper Class="mud-width-full mud-appbar sticky-bottom" Square Height="15vh">
+<MudPaper Class="mud-width-full mud-appbar footer-sticky" Square Height="15vh">
 
     <MudText Align="Align.Center" Typo="Typo.h3" Color="Color.Primary">Footer</MudText>
 

--- a/TheRestaurant/TheRestaurant.Presentation/Client/Shared/MainLayout.razor
+++ b/TheRestaurant/TheRestaurant.Presentation/Client/Shared/MainLayout.razor
@@ -20,7 +20,7 @@
     </MudAppBar>
 
 
-    <MudDrawer @bind-Open="@_drawerOpen" DisableOverlay="true">
+    <MudDrawer @bind-Open="@_drawerOpen" Variant="DrawerVariant.Temporary">
         <MainNavMenu />
     </MudDrawer>
 


### PR DESCRIPTION
The Drawer component on the main layout now pops out over the site, instead of shoving it all to the side.